### PR TITLE
Introduce JSONStorage for better persistence abstraction

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import simpledialog, messagebox, ttk
 import config
 from questions import Question, YesNoQuestion, MultiChoiceQuestion
+from storage_json import JSONStorage
 
 class AdminUI(tk.Tk):
     def __init__(self, storage):
@@ -17,7 +18,7 @@ class AdminUI(tk.Tk):
         # objects so we can work with them directly.
         self.questions = storage.load_questions()
         self.diseases = storage.load_diseases()
-        self.diagnosis_model = storage.load_model()
+        self.diagnosis_model = storage.load_diagnosis_model()
         self.create_widgets()
 
     def create_widgets(self):
@@ -172,5 +173,11 @@ class AdminUI(tk.Tk):
         # Persist all modifications back to disk using the storage helpers.
         self.storage.save_questions(self.questions)
         self.storage.save_diseases(self.diseases)
-        self.storage.save_model(self.diagnosis_model)
+        self.storage.save_diagnosis_model(self.diagnosis_model)
         messagebox.showinfo("Saved", "All data saved!")
+
+
+if __name__ == "__main__":
+    storage = JSONStorage()
+    app = AdminUI(storage)
+    app.mainloop()

--- a/storage_json.py
+++ b/storage_json.py
@@ -4,37 +4,85 @@ from typing import Iterable, List
 from config import QUESTIONS_FILE, DISEASES_FILE, DIAGNOSIS_MODEL_FILE
 from questions import Question
 
+
+class JSONStorage:
+    """Helper class for reading/writing project JSON files."""
+
+    def __init__(self,
+                 questions_file: str = QUESTIONS_FILE,
+                 diseases_file: str = DISEASES_FILE,
+                 diagnosis_model_file: str = DIAGNOSIS_MODEL_FILE) -> None:
+        self.questions_file = questions_file
+        self.diseases_file = diseases_file
+        self.diagnosis_model_file = diagnosis_model_file
+
+    # ------------------------------------------------------------------
+    # Questions helpers
+    def load_questions(self) -> List[Question]:
+        """Load questions and return ``Question`` objects."""
+        with open(self.questions_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return [Question.from_dict(q) for q in data]
+
+    def save_questions(self, questions: Iterable[Question]) -> None:
+        """Persist questions to disk."""
+        data = [q.to_dict() for q in questions]
+        with open(self.questions_file, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    # ------------------------------------------------------------------
+    # Diseases helpers
+    def load_diseases(self) -> List[str]:
+        """Return the list of diseases."""
+        with open(self.diseases_file, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def save_diseases(self, diseases: Iterable[str]) -> None:
+        """Write the diseases list back to disk."""
+        with open(self.diseases_file, "w", encoding="utf-8") as f:
+            json.dump(list(diseases), f, indent=2)
+
+    # ------------------------------------------------------------------
+    # Diagnosis model helpers
+    def load_diagnosis_model(self) -> dict:
+        """Return the diagnosis model mapping."""
+        with open(self.diagnosis_model_file, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def save_diagnosis_model(self, model: dict) -> None:
+        """Persist the diagnosis model mapping."""
+        with open(self.diagnosis_model_file, "w", encoding="utf-8") as f:
+            json.dump(model, f, indent=2)
+
+# Default storage used by the module level helper functions below
+_default_storage = JSONStorage()
+
+
 def load_questions() -> List[Question]:
-    """Load questions from disk and return ``Question`` objects."""
-    with open(QUESTIONS_FILE, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    return [Question.from_dict(q) for q in data]
-
-def load_diseases() -> List[str]:
-    """Return the list of diseases from disk."""
-    with open(DISEASES_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
-
-def load_model() -> dict:
-    """Return the diagnosis model mapping."""
-    with open(DIAGNOSIS_MODEL_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+    """Load questions using the default storage instance."""
+    return _default_storage.load_questions()
 
 
 def save_questions(questions: Iterable[Question]) -> None:
-    """Persist questions to ``QUESTIONS_FILE``."""
-    data = [q.to_dict() for q in questions]
-    with open(QUESTIONS_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+    """Persist questions using the default storage instance."""
+    _default_storage.save_questions(questions)
+
+
+def load_diseases() -> List[str]:
+    """Load diseases using the default storage instance."""
+    return _default_storage.load_diseases()
 
 
 def save_diseases(diseases: Iterable[str]) -> None:
-    """Write the diseases list back to disk."""
-    with open(DISEASES_FILE, "w", encoding="utf-8") as f:
-        json.dump(list(diseases), f, indent=2)
+    """Persist diseases using the default storage instance."""
+    _default_storage.save_diseases(diseases)
+
+
+def load_model() -> dict:
+    """Backward compatible wrapper for loading the diagnosis model."""
+    return _default_storage.load_diagnosis_model()
 
 
 def save_model(model: dict) -> None:
-    """Persist the diagnosis model mapping."""
-    with open(DIAGNOSIS_MODEL_FILE, "w", encoding="utf-8") as f:
-        json.dump(model, f, indent=2)
+    """Backward compatible wrapper for saving the diagnosis model."""
+    _default_storage.save_diagnosis_model(model)


### PR DESCRIPTION
## Summary
- implement `JSONStorage` class in `storage_json.py`
- expose compatibility helpers using a default instance
- update `AdminUI` to use `JSONStorage`
- add runnable entry point for the admin UI

## Testing
- `python -m py_compile storage_json.py admin.py ui.py engine_rule.py questions.py config.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_683f911e0238832fba7c1a8b471f69de