### PR TITLE
Refactor tkinter usage in ui module

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1,5 +1,5 @@
 
-from tkinter import *
+from tkinter import Label, Button, Frame, LEFT
 from engine_rule import DiagnosisEngine
 from storage_json import load_questions, load_diseases, load_model
 


### PR DESCRIPTION
## Summary
- replace wildcard `tkinter` import with explicit widget imports
- update widget constructors to use imported symbols directly

## Testing
- `python -m py_compile ui.py admin.py main.py engine_rule.py questions.py storage_json.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_683f9120eaf0832f97cda782a9f549c4