### PR TITLE
Improve code quality and configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ Launch it with:
 python admin.py
 ```
 
+## Data Format
+
+All application data lives in the `data/` directory. It contains three JSON
+files:
+
+- `questions.json` – list of questions with optional multiple choice options.
+- `diseases.json` – array of disease names.
+- `diagnosis_model.json` – nested mapping of disease -> question -> answer -> weight.
+
+You can modify these files directly or use the admin interface which ensures the
+structure remains valid.
+
 ## Debugging
 
 The diagnostic engine supports debug logging. Set the environment variable
@@ -38,3 +50,9 @@ The diagnostic engine supports debug logging. Set the environment variable
   (it is included with most standard Python distributions)
 
 No third‑party packages are required.
+
+## Contributing
+
+Pull requests are welcome! Please ensure that unit tests continue to pass by
+running `pytest` before submitting. Feel free to open issues if you encounter
+problems or have suggestions for improvement.

--- a/admin.py
+++ b/admin.py
@@ -39,11 +39,18 @@ class AdminUI(tk.Tk):
         self.config(menu=menubar)
 
     def create_widgets(self):
-        nb = ttk.Notebook(self)
-        nb.pack(expand=1, fill=tk.BOTH)
-        # Questions tab
-        frm_q = tk.Frame(nb, bg=config.THEME_BG)
-        nb.add(frm_q, text="Questions")
+        self.nb = ttk.Notebook(self)
+        self.nb.pack(expand=1, fill=tk.BOTH)
+
+        self.create_questions_tab()
+        self.create_diseases_tab()
+        self.create_weights_tab()
+        tk.Button(self, text="Save All", command=self.save_all, font=("Arial", 14)).pack(pady=5)
+
+    def create_questions_tab(self):
+        frm_q = tk.Frame(self.nb, bg=config.THEME_BG)
+        self.nb.add(frm_q, text="Questions")
+
         search_frame = tk.Frame(frm_q, bg=config.THEME_BG)
         search_frame.pack(fill=tk.X, padx=6, pady=(6, 0))
         tk.Label(search_frame, text="Search:", bg=config.THEME_BG).pack(side=tk.LEFT)
@@ -52,95 +59,49 @@ class AdminUI(tk.Tk):
         self.q_search_var.trace_add("write", lambda *a: self.refresh_q_list())
 
         self.q_listbox = tk.Listbox(frm_q, font=("Arial", 16), width=55)
-        self.q_listbox.pack(
-            side=tk.LEFT, fill=tk.BOTH, expand=True, padx=6, pady=4
-        )
-        q_scroll = tk.Scrollbar(
-            frm_q, orient=tk.VERTICAL, command=self.q_listbox.yview
-        )
+        self.q_listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=6, pady=4)
+        q_scroll = tk.Scrollbar(frm_q, orient=tk.VERTICAL, command=self.q_listbox.yview)
         q_scroll.pack(side=tk.LEFT, fill=tk.Y)
         self.q_listbox.config(yscrollcommand=q_scroll.set)
         self.refresh_q_list()
+
         btns_q = tk.Frame(frm_q, bg=config.THEME_BG)
         btns_q.pack(side=tk.LEFT, padx=6)
-        tk.Button(
-            btns_q,
-            text="Add",
-            command=self.add_q,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        tk.Button(
-            btns_q,
-            text="Edit",
-            command=self.edit_q,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        tk.Button(
-            btns_q,
-            text="Move Up",
-            command=self.move_q_up,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        tk.Button(
-            btns_q,
-            text="Move Down",
-            command=self.move_q_down,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        tk.Button(
-            btns_q,
-            text="Delete",
-            command=self.del_q,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        # Diseases tab
-        frm_d = tk.Frame(nb, bg=config.THEME_BG)
-        nb.add(frm_d, text="Diseases")
+        for txt, cmd in [
+            ("Add", self.add_q),
+            ("Edit", self.edit_q),
+            ("Move Up", self.move_q_up),
+            ("Move Down", self.move_q_down),
+            ("Delete", self.del_q),
+        ]:
+            tk.Button(btns_q, text=txt, command=cmd, font=("Arial", 16)).pack(fill=tk.X)
+
+    def create_diseases_tab(self):
+        frm_d = tk.Frame(self.nb, bg=config.THEME_BG)
+        self.nb.add(frm_d, text="Diseases")
+
         self.d_listbox = tk.Listbox(frm_d, font=("Arial", 16), width=35)
-        self.d_listbox.pack(
-            side=tk.LEFT, fill=tk.BOTH, expand=True, padx=6, pady=4
-        )
-        d_scroll = tk.Scrollbar(
-            frm_d, orient=tk.VERTICAL, command=self.d_listbox.yview
-        )
+        self.d_listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=6, pady=4)
+        d_scroll = tk.Scrollbar(frm_d, orient=tk.VERTICAL, command=self.d_listbox.yview)
         d_scroll.pack(side=tk.LEFT, fill=tk.Y)
         self.d_listbox.config(yscrollcommand=d_scroll.set)
         self.refresh_d_list()
+
         btns_d = tk.Frame(frm_d, bg=config.THEME_BG)
         btns_d.pack(side=tk.LEFT, padx=6)
-        tk.Button(
-            btns_d,
-            text="Add",
-            command=self.add_d,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        tk.Button(
-            btns_d,
-            text="Edit",
-            command=self.edit_d,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        tk.Button(
-            btns_d,
-            text="Move Up",
-            command=self.move_d_up,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        tk.Button(
-            btns_d,
-            text="Move Down",
-            command=self.move_d_down,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        tk.Button(
-            btns_d,
-            text="Delete",
-            command=self.del_d,
-            font=("Arial", 16),
-        ).pack(fill=tk.X)
-        # Weights tab
-        frm_w = tk.Frame(nb, bg=config.THEME_BG)
-        nb.add(frm_w, text="Weights")
+        for txt, cmd in [
+            ("Add", self.add_d),
+            ("Edit", self.edit_d),
+            ("Move Up", self.move_d_up),
+            ("Move Down", self.move_d_down),
+            ("Delete", self.del_d),
+        ]:
+            tk.Button(btns_d, text=txt, command=cmd, font=("Arial", 16)).pack(fill=tk.X)
+
+    def create_weights_tab(self):
+        frm_w = tk.Frame(self.nb, bg=config.THEME_BG)
+        self.nb.add(frm_w, text="Weights")
+
         tk.Label(
             frm_w,
             text="Select disease, question, and assign weights per answer.",
@@ -149,26 +110,15 @@ class AdminUI(tk.Tk):
         ).pack()
         frm_top = tk.Frame(frm_w, bg=config.THEME_BG)
         frm_top.pack()
-        self.disease_combo = ttk.Combobox(
-            frm_top, values=self.diseases, font=("Arial", 14)
-        )
+        self.disease_combo = ttk.Combobox(frm_top, values=self.diseases, font=("Arial", 14))
         self.disease_combo.pack(side=tk.LEFT, padx=7)
-        self.disease_combo.bind(
-            "<<ComboboxSelected>>",
-            lambda event: self.refresh_weight_q(),
-        )
-        self.q_combo = ttk.Combobox(
-            frm_top, values=[q.qid for q in self.questions], font=("Arial", 14)
-        )
+        self.disease_combo.bind("<<ComboboxSelected>>", lambda e: self.refresh_weight_q())
+        self.q_combo = ttk.Combobox(frm_top, values=[q.qid for q in self.questions], font=("Arial", 14))
         self.q_combo.pack(side=tk.LEFT, padx=7)
-        self.q_combo.bind(
-            "<<ComboboxSelected>>",
-            lambda event: self.refresh_weight_q(),
-        )
+        self.q_combo.bind("<<ComboboxSelected>>", lambda e: self.refresh_weight_q())
         self.ans_frame = tk.Frame(frm_w, bg=config.THEME_BG)
         self.ans_frame.pack(pady=10)
         tk.Button(frm_w, text="Set Weight", command=self.set_weight, font=("Arial", 14)).pack()
-        tk.Button(self, text="Save All", command=self.save_all, font=("Arial", 14)).pack(pady=5)
 
     def refresh_q_list(self):
         self.q_listbox.delete(0, tk.END)

--- a/config.py
+++ b/config.py
@@ -1,8 +1,25 @@
+"""Configuration helpers and defaults for the application."""
+
 import os
-DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
-QUESTIONS_FILE = os.path.join(DATA_DIR, "questions.json")
-DISEASES_FILE = os.path.join(DATA_DIR, "diseases.json")
-DIAGNOSIS_MODEL_FILE = os.path.join(DATA_DIR, "diagnosis_model.json")
+
+
+def _get_env_or_default(name: str, default: str) -> str:
+    """Return ``name`` from the environment or ``default`` if unset."""
+
+    return os.getenv(name, default)
+
+
+BASE_DIR = os.path.dirname(__file__)
+DATA_DIR = _get_env_or_default("AIVO_DATA_DIR", os.path.join(BASE_DIR, "data"))
+QUESTIONS_FILE = _get_env_or_default(
+    "AIVO_QUESTIONS_FILE", os.path.join(DATA_DIR, "questions.json")
+)
+DISEASES_FILE = _get_env_or_default(
+    "AIVO_DISEASES_FILE", os.path.join(DATA_DIR, "diseases.json")
+)
+DIAGNOSIS_MODEL_FILE = _get_env_or_default(
+    "AIVO_DIAGNOSIS_MODEL_FILE", os.path.join(DATA_DIR, "diagnosis_model.json")
+)
 
 # Default UI configuration values.  AdminUI relies on these constants
 # when sizing and styling its windows.  They previously did not exist

--- a/main.py
+++ b/main.py
@@ -1,7 +1,20 @@
+"""Entry point for the diagnosis UI."""
+
+
 from tkinter import Tk
+import argparse
 from ui import DiagnosisUI
 
-if __name__ == "__main__":
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the diagnosis UI")
+    parser.add_argument("--debug", action="store_true", help="enable debug mode")
+    args = parser.parse_args()
+
     root = Tk()
-    app = DiagnosisUI(root)
+    DiagnosisUI(root, debug=args.debug)
     root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/questions.py
+++ b/questions.py
@@ -1,13 +1,22 @@
+"""Question model classes."""
 
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
 class Question:
-    def __init__(self, qid, text, qtype, choices=None):
-        self.qid = qid
-        self.text = text
-        self.qtype = qtype
-        self.choices = choices or []
+    """Represent a single question."""
+
+    qid: str
+    text: str
+    qtype: str
+    choices: Optional[List[str]] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data):
+        """Instantiate from a dictionary produced by ``to_dict``."""
+
         return cls(
             data["id"],
             data["text"],
@@ -16,6 +25,8 @@ class Question:
         )
 
     def to_dict(self):
+        """Return ``dict`` representation for JSON serialization."""
+
         d = {
             "id": self.qid,
             "text": self.text,

--- a/storage_json.py
+++ b/storage_json.py
@@ -7,37 +7,61 @@ from questions import Question
 
 def load_questions() -> List[Question]:
     """Load questions from disk and return ``Question`` objects."""
-    with open(QUESTIONS_FILE, "r", encoding="utf-8") as f:
-        data = json.load(f)
+
+    try:
+        with open(QUESTIONS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Failed to load questions: {exc}") from exc
     return [Question.from_dict(q) for q in data]
 
 
 def load_diseases() -> List[str]:
     """Return the list of diseases from disk."""
-    with open(DISEASES_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+
+    try:
+        with open(DISEASES_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Failed to load diseases: {exc}") from exc
 
 
 def load_model() -> dict:
     """Return the diagnosis model mapping."""
-    with open(DIAGNOSIS_MODEL_FILE, "r", encoding="utf-8") as f:
-        return json.load(f)
+
+    try:
+        with open(DIAGNOSIS_MODEL_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Failed to load model: {exc}") from exc
 
 
 def save_questions(questions: Iterable[Question]) -> None:
     """Persist questions to ``QUESTIONS_FILE``."""
+
     data = [q.to_dict() for q in questions]
-    with open(QUESTIONS_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+    try:
+        with open(QUESTIONS_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError as exc:
+        raise RuntimeError(f"Failed to save questions: {exc}") from exc
 
 
 def save_diseases(diseases: Iterable[str]) -> None:
     """Write the diseases list back to disk."""
-    with open(DISEASES_FILE, "w", encoding="utf-8") as f:
-        json.dump(list(diseases), f, indent=2)
+
+    try:
+        with open(DISEASES_FILE, "w", encoding="utf-8") as f:
+            json.dump(list(diseases), f, indent=2)
+    except OSError as exc:
+        raise RuntimeError(f"Failed to save diseases: {exc}") from exc
 
 
 def save_model(model: dict) -> None:
     """Persist the diagnosis model mapping."""
-    with open(DIAGNOSIS_MODEL_FILE, "w", encoding="utf-8") as f:
-        json.dump(model, f, indent=2)
+
+    try:
+        with open(DIAGNOSIS_MODEL_FILE, "w", encoding="utf-8") as f:
+            json.dump(model, f, indent=2)
+    except OSError as exc:
+        raise RuntimeError(f"Failed to save model: {exc}") from exc

--- a/tests/test_engine_rule.py
+++ b/tests/test_engine_rule.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import logging
+import math
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
 import pytest  # noqa: E402
@@ -38,3 +40,15 @@ def test_select_best_question_progression(engine):
     engine.answer_question(first, 'Yes')
     second = engine.select_best_question()
     assert second == 'pain'
+
+
+def test_entropy_with_zero_scores():
+    eng = DiagnosisEngine(['D1', 'D2'], ['q1'], {'D1': {}, 'D2': {}})
+    ent = eng.compute_entropy()
+    assert ent == pytest.approx(math.log2(2))
+
+
+def test_model_missing_weights_logs_warning(caplog):
+    caplog.set_level(logging.WARNING)
+    DiagnosisEngine(['D1'], ['q1', 'q2'], {'D1': {'q1': {'Yes': 1}}})
+    assert any('missing weights' in r.message for r in caplog.records)

--- a/ui.py
+++ b/ui.py
@@ -1,4 +1,6 @@
 
+"""Graphical user interface for the diagnostic questionnaire."""
+
 import os
 import tkinter as tk
 from tkinter import ttk
@@ -7,14 +9,17 @@ from storage_json import load_questions, load_diseases, load_model
 
 
 class DiagnosisUI:
-    def __init__(self, master):
+    """Interactive Tkinter UI driving ``DiagnosisEngine``."""
+
+    def __init__(self, master, *, debug: bool | None = None):
         self.master = master
         self.questions = load_questions()
         self.diseases = load_diseases()
         self.model = load_model()
         # ``load_questions`` now returns ``Question`` objects
         self.question_ids = [q.qid for q in self.questions]
-        debug = bool(os.getenv("AIVO_DEBUG"))
+        if debug is None:
+            debug = bool(os.getenv("AIVO_DEBUG"))
         self.engine = DiagnosisEngine(
             self.diseases,
             self.question_ids,


### PR DESCRIPTION
## Summary
- allow environment-based configuration for file paths
- convert `Question` to a dataclass
- add model validation and docstrings to `DiagnosisEngine`
- add error handling for JSON storage helpers
- refactor Admin UI widget creation into helper methods
- add CLI debug flag and docstrings
- extend README with data format and contribution tips
- add additional engine rule tests

## Testing
- `flake8 --ignore=E501`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa94dc5b8832fb167a1d8997ce2f0