### PR TITLE
Add interactive training tab to admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ python main.py
 The admin panel allows you to add or remove questions, manage diseases and
 adjust the weight mapping used by the diagnostic engine. A search box makes it
 easy to locate questions. Items can be reordered with **Move Up/Down** buttons
-and all changes are saved using the **File** menu.
+and all changes are saved using the **File** menu. A **Training** tab lets you
+quickly rate how strongly each question is associated with a disease using a
+0‑5 slider. Click **Record Rating** and then **Save All** to persist the new
+weights.
 Launch it with:
 
 ```bash


### PR DESCRIPTION
## Summary
- add new **Training** tab to AdminUI for rating question/disease associations
- persist rating to diagnosis model
- show tips explaining how to use the tab
- document the feature in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc0ed5aec832f8e55f60bda300f35