### PR TITLE
Add random pair button to training tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ adjust the weight mapping used by the diagnostic engine. A search box makes it
 easy to locate questions. Items can be reordered with **Move Up/Down** buttons
 and all changes are saved using the **File** menu. A **Training** tab lets you
 quickly rate how strongly each question is associated with a disease using a
-0‑5 slider. Click **Record Rating** and then **Save All** to persist the new
-weights.
+0‑5 slider. Use **Random Pair** to pick a disease/question combination, then
+click **Record Rating** and **Save All** to persist the new weights.
 Launch it with:
 
 ```bash

--- a/admin.py
+++ b/admin.py
@@ -12,6 +12,8 @@ JSON files under the ``data/`` directory.
 from tkinter import simpledialog, messagebox, ttk, TclError
 import os
 import sys
+import random
+import logging
 import config
 from questions import YesNoQuestion, MultiChoiceQuestion
 
@@ -21,6 +23,7 @@ class AdminUI(tk.Tk):
 
     def __init__(self, storage):
         super().__init__()
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.title("Admin Panel - Veterinary Ophthalmology")
         self.geometry(f"{config.SCREEN_WIDTH}x{config.SCREEN_HEIGHT}")
         self.resizable(False, False)
@@ -187,6 +190,8 @@ class AdminUI(tk.Tk):
         self.rating_scale = tk.Scale(frm_t, from_=0, to=5, orient=tk.HORIZONTAL, variable=self.rating_var, length=400)
         self.rating_scale.pack()
 
+        tk.Button(frm_t, text="Random Pair", command=self.random_training_pair, font=config.FONT_SMALL).pack(pady=(5, 0))
+
         tk.Button(frm_t, text="Record Rating", command=self.save_training_rating, font=config.FONT_SMALL).pack(pady=(5, 0))
         tk.Button(frm_t, text="Tips", command=self.show_training_tips, font=config.FONT_SMALL).pack(pady=(10, 0))
 
@@ -231,6 +236,16 @@ class AdminUI(tk.Tk):
             "Select a disease and question then drag the slider to set how strongly the question suggests the disease."
             " Click Record Rating to store the value and Save All when finished.",
         )
+
+    def random_training_pair(self):
+        """Pick a random disease/question pair for training."""
+        disease = random.choice(self.diseases)
+        question = random.choice([q.qid for q in self.questions])
+        self.train_disease.set(disease)
+        self.train_question.set(question)
+        self.update_training_prompt()
+        self.rating_var.set(0)
+        self.logger.info("Random training pair: %s / %s", disease, question)
 
     def refresh_q_list(self):
         """Refresh the list of questions, applying any search filter."""


### PR DESCRIPTION
## Summary
- allow admins to pick a random disease/question pair for training
- expose Random Pair button in Admin UI
- document the button in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc4feaf48832f9de5148d95fbbf44