### PR TITLE
Add configurable diagnosis window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ structure remains valid.
 The diagnostic engine supports debug logging. Set the environment variable
 `AIVO_DEBUG=1` before running the UI or tests to see detailed log output.
 
+The size of the diagnosis window can also be adjusted with environment
+variables. Set `AIVO_DIAG_SCREEN_WIDTH` and `AIVO_DIAG_SCREEN_HEIGHT`
+to override the default 800x480 geometry used by the questionnaire UI.
+
 ## Dependencies
 
 - Python 3.9 or later

--- a/config.py
+++ b/config.py
@@ -26,6 +26,15 @@ DIAGNOSIS_MODEL_FILE = _get_env_or_default(
 # which caused attribute errors on start up.
 SCREEN_WIDTH = 1024
 SCREEN_HEIGHT = 768
+# Size of the diagnosis questionnaire window.  Can be overridden with
+# ``AIVO_DIAG_SCREEN_WIDTH`` and ``AIVO_DIAG_SCREEN_HEIGHT`` environment
+# variables which is helpful when running on small displays.
+DIAG_SCREEN_WIDTH = int(
+    _get_env_or_default("AIVO_DIAG_SCREEN_WIDTH", "800")
+)
+DIAG_SCREEN_HEIGHT = int(
+    _get_env_or_default("AIVO_DIAG_SCREEN_HEIGHT", "480")
+)
 THEME_BG = "#f0f0f0"
 
 # Font configuration used across the Tkinter interfaces. These

--- a/ui.py
+++ b/ui.py
@@ -35,7 +35,9 @@ class DiagnosisUI:
 
     def init_ui(self):
         self.master.title("Vet Ophthalmology Diagnosis")
-        self.master.geometry("800x480")
+        self.master.geometry(
+            f"{config.DIAG_SCREEN_WIDTH}x{config.DIAG_SCREEN_HEIGHT}"
+        )
         self.master.resizable(False, False)
         self.master.configure(bg=config.THEME_BG, padx=20, pady=20)
 


### PR DESCRIPTION
## Summary
- add `DIAG_SCREEN_WIDTH` and `DIAG_SCREEN_HEIGHT` with env overrides
- resize diagnosis UI using new config values
- document new env vars in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd30bc3ec832f953e6442bfae0677