### PR TITLE
Add undo/back functionality

### DIFF
--- a/tests/test_engine_rule.py
+++ b/tests/test_engine_rule.py
@@ -52,3 +52,24 @@ def test_model_missing_weights_logs_warning(caplog):
     caplog.set_level(logging.WARNING)
     DiagnosisEngine(['D1'], ['q1', 'q2'], {'D1': {'q1': {'Yes': 1}}})
     assert any('missing weights' in r.message for r in caplog.records)
+
+
+def test_undo_reverts_scores_and_history(engine):
+    engine.answer_question('red_eye', 'Yes')
+    assert engine.history == ['red_eye']
+    engine.undo_last_answer()
+    assert engine.history == []
+    assert 'red_eye' not in engine.answered
+    assert 'red_eye' in engine.remaining_questions
+    for val in engine.scores.values():
+        assert val == 0
+
+
+def test_undo_returns_previous_question(engine):
+    engine.answer_question('red_eye', 'Yes')
+    engine.answer_question('pain', 'No')
+    assert engine.history == ['red_eye', 'pain']
+    qid = engine.undo_last_answer()
+    assert qid == 'pain'
+    assert engine.history == ['red_eye']
+    assert 'pain' not in engine.answered

--- a/ui.py
+++ b/ui.py
@@ -87,12 +87,23 @@ class DiagnosisUI:
             style="Result.TLabel",
         )
         self.result_label.pack(pady=20)
+        self.nav_frame = ttk.Frame(self.master)
+        self.nav_frame.pack(pady=10)
+        self.back_button = ttk.Button(
+            self.nav_frame,
+            text="Back",
+            command=self.go_back,
+            style="Answer.TButton",
+        )
+        self.back_button.pack(side=tk.LEFT, padx=5)
         self.restart_button = ttk.Button(
-            self.master,
+            self.nav_frame,
             text="Restart",
             command=self.restart,
             style="Answer.TButton",
         )
+        self.restart_button.pack(side=tk.LEFT, padx=5)
+        self.back_button.pack_forget()
         self.restart_button.pack_forget()
 
     def clear_buttons(self):
@@ -108,6 +119,7 @@ class DiagnosisUI:
         self.qprogress_label.config(text="")
         self.progress_bar['value'] = 0
         self.restart_button.pack_forget()
+        self.back_button.pack_forget()
         self.next_question()
 
     def display_question(self, question_id):
@@ -130,6 +142,17 @@ class DiagnosisUI:
         self.update_progress()
         self.next_question()
 
+    def go_back(self):
+        """Undo the last answer and show the previous question."""
+        qid = self.engine.undo_last_answer()
+        if qid is None:
+            return
+        self.result_label.config(text="")
+        self.restart_button.pack_forget()
+        self.current_question = qid
+        self.display_question(qid)
+        self.update_progress()
+
     def update_progress(self):
         scores = self.engine.get_scores()
         top = self.engine.get_top_diseases()
@@ -141,6 +164,10 @@ class DiagnosisUI:
         )
         percent = answered / self.total_questions * 100
         self.progress_bar['value'] = percent
+        if self.engine.history:
+            self.back_button.pack(side=tk.LEFT, padx=5)
+        else:
+            self.back_button.pack_forget()
 
     def next_question(self):
         if self.engine.is_done():
@@ -156,7 +183,9 @@ class DiagnosisUI:
                 text=f"Question {answered} of {self.total_questions}"
             )
             self.progress_bar['value'] = 100
-            self.restart_button.pack(pady=10)
+            self.restart_button.pack(side=tk.LEFT, padx=5)
+            if self.engine.history:
+                self.back_button.pack(side=tk.LEFT, padx=5)
             return
         qid = self.engine.select_best_question()
         if not qid:


### PR DESCRIPTION
## Summary
- extend `DiagnosisEngine` with `history` tracking and `undo_last_answer`
- show Back navigation in the GUI
- add unit tests for undo functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd89a4e04832f90f6f5cf4d0c81b8