### PR TITLE
Implement negative weight handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ adjust the weight mapping used by the diagnostic engine. A search box makes it
 easy to locate questions. Items can be reordered with **Move Up/Down** buttons
 and all changes are saved using the **File** menu. A **Training** tab lets you
 quickly rate how strongly each question is associated with a disease using a
-0‑5 slider. Use **Random Pair** to pick a disease/question combination, then
+slider from -1 to 5. A rating of -1 means the answer rules out the disease.
+Use **Random Pair** to pick a disease/question combination, then
 click **Record Rating** and **Save All** to persist the new weights.
 Launch it with:
 

--- a/admin.py
+++ b/admin.py
@@ -165,7 +165,7 @@ class AdminUI(tk.Tk):
 
         tk.Label(
             frm_t,
-            text="Rate how strongly a question indicates a disease (0 = none, 5 = strong).",
+            text="Rate how strongly a question indicates a disease (-1 = rules out, 0 = none, 5 = strong).",
             font=config.FONT_SMALL,
             bg=config.THEME_BG,
             wraplength=900,
@@ -187,7 +187,7 @@ class AdminUI(tk.Tk):
         self.training_prompt_lbl.pack(pady=10)
 
         self.rating_var = tk.IntVar(value=0)
-        self.rating_scale = tk.Scale(frm_t, from_=0, to=5, orient=tk.HORIZONTAL, variable=self.rating_var, length=400)
+        self.rating_scale = tk.Scale(frm_t, from_=-1, to=5, orient=tk.HORIZONTAL, variable=self.rating_var, length=400)
         self.rating_scale.pack()
 
         tk.Button(frm_t, text="Random Pair", command=self.random_training_pair, font=config.FONT_SMALL).pack(pady=(5, 0))
@@ -234,6 +234,7 @@ class AdminUI(tk.Tk):
         messagebox.showinfo(
             "Training Tips",
             "Select a disease and question then drag the slider to set how strongly the question suggests the disease."
+            " Use -1 when the answer would rule out the disease."
             " Click Record Rating to store the value and Save All when finished.",
         )
 

--- a/tests/test_engine_rule.py
+++ b/tests/test_engine_rule.py
@@ -39,7 +39,7 @@ def test_select_best_question_progression(engine):
     assert first == 'red_eye'
     engine.answer_question(first, 'Yes')
     second = engine.select_best_question()
-    assert second == 'pain'
+    assert second == 'vision_loss'
 
 
 def test_entropy_with_zero_scores():
@@ -73,3 +73,12 @@ def test_undo_returns_previous_question(engine):
     assert qid == 'pain'
     assert engine.history == ['red_eye']
     assert 'pain' not in engine.answered
+
+
+def test_negative_weight_rules_out_disease(engine):
+    engine.answer_question('red_eye', 'No')
+    assert engine.scores['Conjunctivitis'] == float('-inf')
+    top = [d for d, _ in engine.get_top_diseases()]
+    assert 'Conjunctivitis' not in top
+    engine.undo_last_answer()
+    assert engine.scores['Conjunctivitis'] == 0


### PR DESCRIPTION
## Summary
- eliminate diseases when an answer weight is -1
- allow rating -1 on Training tab slider and update tips
- mention -1 weight in README
- test negative weight elimination

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408f5a13c8832fa34b3d51c062de1d