### PR TITLE
Fix redundant diagnosis messages

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -183,6 +183,8 @@ class DiagnosisUI:
         if self.engine.is_done():
             self.question_label.config(text="Diagnosis complete.")
             self.clear_buttons()
+            # Clear interim progress to avoid repeating the final results
+            self.progress_label.config(text="")
             top = self.engine.get_top_diseases()
             text = "\n".join(
                 [f"{d}: {score:.2f}" for d, score in top]


### PR DESCRIPTION
## Summary
- clear the progress label when the diagnosis is complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409b7fc0f0832f822ba11f292cc1a8