### PR TITLE
Enhance professionalism of UI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ is included for editing questions, diseases and diagnosis weights.
 
 Execute `main.py` with Python. A window will guide you through a set of
 questions and display the most likely diseases at the end.
-The window includes a **Help** menu that opens an About dialog with
-basic instructions.
+The window includes a **Help** menu with an About dialog summarizing
+how to use the tool.
 
 ```bash
 python main.py

--- a/admin.py
+++ b/admin.py
@@ -423,9 +423,9 @@ class AdminUI(tk.Tk):
         """Display basic help and usage instructions."""
         messagebox.showinfo(
             "About",
-            """This admin panel lets you maintain the questions, diseases \
-and weighting model used by the diagnostic tool. Use the tabs above \
-to add or edit data and click \"Save All\" when finished.""",
+            """Administrative panel for AIVO\n\n"
+            "Use the tabs to manage questions, diseases and weighting factors. "
+            "Click 'Save All' to store your changes.""",
         )
 
     def show_q_tips(self):

--- a/config.py
+++ b/config.py
@@ -57,6 +57,6 @@ THEME_BG = "#f0f0f0"
 # Font configuration used across the Tkinter interfaces. These
 # consolidate the various hard-coded font tuples previously scattered
 # throughout the UI modules which made the look and feel inconsistent.
-FONT_LARGE = ("Arial", 24)
-FONT_MEDIUM = ("Arial", 16)
-FONT_SMALL = ("Arial", 14)
+FONT_LARGE = ("Helvetica", 24)
+FONT_MEDIUM = ("Helvetica", 16)
+FONT_SMALL = ("Helvetica", 14)

--- a/ui.py
+++ b/ui.py
@@ -45,13 +45,18 @@ class DiagnosisUI:
         help_menu.add_command(
             label="About",
             command=lambda: messagebox.showinfo(
-                "About", "Brief instructions and project info"
+                "About",
+                """Veterinary Ophthalmology Diagnostic Tool\n\n"
+                "Answer each question to the best of your ability.\n"
+                "The system ranks likely diseases based on your responses.""",
             ),
         )
         menubar.add_cascade(label="Help", menu=help_menu)
         self.master.config(menu=menubar)
 
         self.style = ttk.Style(self.master)
+        if "clam" in self.style.theme_names():
+            self.style.theme_use("clam")
         self.style.configure(
             "Question.TLabel",
             font=config.FONT_LARGE,


### PR DESCRIPTION
## Summary
- refine About dialogs for user-facing UIs
- switch interface fonts to Helvetica
- use "clam" ttk theme when available
- tweak README instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c982279c832f9888d1c140813dc0