### PR TITLE
Add HTML5 web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ to override the default 800x480 geometry used by the questionnaire UI.
 
 No third‑party packages are required.
 
+## Using the Web Version
+A lightweight HTML5/JavaScript front end is available under the `web/` folder. It uses the same JSON data files and runs entirely in the browser. Launch a local web server and open `web/index.html` in your browser:
+
+```bash
+python -m http.server 8000
+# then navigate to http://localhost:8000/web/index.html
+```
+
+
 ## Contributing
 
 Pull requests are welcome! Please ensure that unit tests continue to pass by

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,90 @@
+import { DiagnosisEngine } from './engine.js';
+
+async function loadData() {
+  const [questions, diseases, model] = await Promise.all([
+    fetch('../data/questions.json').then(r => r.json()),
+    fetch('../data/diseases.json').then(r => r.json()),
+    fetch('../data/diagnosis_model.json').then(r => r.json()),
+  ]);
+  return { questions, diseases, model };
+}
+
+function createEngine(data) {
+  const questionIds = data.questions.map(q => q.id);
+  return new DiagnosisEngine(data.diseases, questionIds, data.model);
+}
+
+function displayQuestion(engine, questions, qid) {
+  const qdata = questions.find(q => q.id === qid);
+  document.getElementById('question').textContent = qdata.text;
+  const btns = document.getElementById('answers');
+  btns.innerHTML = '';
+  const options = engine.getPossibleAnswers(qid);
+  options.forEach(ans => {
+    const btn = document.createElement('button');
+    btn.textContent = ans;
+    btn.className = 'answer';
+    btn.onclick = () => {
+      engine.answerQuestion(qid, ans);
+      updateProgress(engine);
+      nextStep(engine, questions);
+    };
+    btns.appendChild(btn);
+  });
+}
+
+function updateProgress(engine) {
+  const scores = engine.getScores();
+  const top = engine.getTopDiseases();
+  const list = top.map(([d,s]) => `${d}: ${scores[d]}`).join('\n');
+  document.getElementById('progress').textContent = `Top Diagnoses:\n${list}`;
+  document.getElementById('back').style.display = engine.history.length ? 'inline-block' : 'none';
+}
+
+function nextStep(engine, questions) {
+  if (engine.isDone()) {
+    document.getElementById('answers').innerHTML = '';
+    const top = engine.getTopDiseases();
+    const text = top.map(([d,s]) => `${d}: ${s.toFixed(2)}`).join('\n');
+    document.getElementById('question').textContent = 'Diagnosis complete.';
+    document.getElementById('progress').textContent = `Most Likely Diagnoses:\n${text}`;
+    document.getElementById('restart').style.display = 'inline-block';
+    document.getElementById('back').style.display = engine.history.length ? 'inline-block' : 'none';
+    return;
+  }
+  const qid = engine.selectBestQuestion();
+  if (!qid) {
+    document.getElementById('question').textContent = 'No more questions.';
+    document.getElementById('answers').innerHTML = '';
+    return;
+  }
+  engine.currentQuestion = qid;
+  displayQuestion(engine, questions, qid);
+}
+
+function goBack(engine, questions) {
+  const qid = engine.undoLastAnswer();
+  if (qid === null) return;
+  document.getElementById('restart').style.display = 'none';
+  displayQuestion(engine, questions, qid);
+  updateProgress(engine);
+}
+
+function restart(engine, questions) {
+  engine.reset();
+  document.getElementById('progress').textContent = '';
+  document.getElementById('restart').style.display = 'none';
+  document.getElementById('back').style.display = 'none';
+  nextStep(engine, questions);
+}
+
+async function init() {
+  const data = await loadData();
+  const engine = createEngine(data);
+  const questions = data.questions;
+  document.getElementById('back').onclick = () => goBack(engine, questions);
+  document.getElementById('restart').onclick = () => restart(engine, questions);
+  nextStep(engine, questions);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/web/engine.js
+++ b/web/engine.js
@@ -1,0 +1,146 @@
+class DiagnosisEngine {
+  constructor(diseases, questions, model) {
+    this.diseases = diseases;
+    this.questions = questions;
+    this.model = model;
+    this.reset();
+  }
+
+  reset() {
+    this.scores = {};
+    this.diseases.forEach(d => { this.scores[d] = 0; });
+    this.answered = {};
+    this.remaining = new Set(this.questions);
+    this.history = [];
+    this.eliminated = {};
+    this.diseases.forEach(d => { this.eliminated[d] = 0; });
+    this._prevScores = {};
+  }
+
+  answerQuestion(question, answer) {
+    this.answered[question] = answer;
+    this.remaining.delete(question);
+    this.history.push(question);
+    this.diseases.forEach(d => {
+      const qmap = this.model[d] || {};
+      if (!(question in qmap)) return;
+      const weight = qmap[question][answer] || 0;
+      if (weight === -1) {
+        if (this.eliminated[d] === 0) {
+          this._prevScores[d] = this.scores[d];
+          this.scores[d] = -Infinity;
+        }
+        this.eliminated[d] += 1;
+      } else if (this.eliminated[d] === 0) {
+        this.scores[d] += weight;
+      }
+    });
+  }
+
+  undoLastAnswer() {
+    if (!this.history.length) return null;
+    const question = this.history.pop();
+    const answer = this.answered[question];
+    delete this.answered[question];
+    this.remaining.add(question);
+    this.diseases.forEach(d => {
+      const qmap = this.model[d] || {};
+      if (!(question in qmap)) return;
+      const weight = qmap[question][answer] || 0;
+      if (weight === -1) {
+        if (this.eliminated[d] > 0) {
+          this.eliminated[d] -= 1;
+          if (this.eliminated[d] === 0) {
+            this.scores[d] = this._prevScores[d] || 0;
+          } else {
+            this.scores[d] = -Infinity;
+          }
+        }
+      } else if (this.eliminated[d] === 0) {
+        this.scores[d] -= weight;
+      }
+    });
+    return question;
+  }
+
+  getPossibleAnswers(question) {
+    for (const d of this.diseases) {
+      const qmap = this.model[d];
+      if (qmap && question in qmap) {
+        return Object.keys(qmap[question]);
+      }
+    }
+    return ["Yes", "No"];
+  }
+
+  computeEntropy(scores = this.scores) {
+    const active = Object.values(scores).filter(v => v !== -Infinity);
+    const values = active.map(v => Math.max(0, v));
+    const total = values.reduce((a, b) => a + b, 0);
+    if (total === 0 || active.length === 0) {
+      return active.length ? Math.log2(active.length) : 0;
+    }
+    const probs = values.map(v => v / total);
+    return -probs.reduce((sum, p) => p > 0 ? sum + p * Math.log2(p) : sum, 0);
+  }
+
+  simulateAnswer(scores, question, answer) {
+    const sim = { ...scores };
+    this.diseases.forEach(d => {
+      const qmap = this.model[d] || {};
+      if (!(question in qmap)) return;
+      const weight = qmap[question][answer] || 0;
+      if (weight === -1) {
+        sim[d] = -Infinity;
+      } else if (sim[d] !== -Infinity) {
+        sim[d] += weight;
+      }
+    });
+    return sim;
+  }
+
+  informationGainForQuestion(question) {
+    const answers = this.getPossibleAnswers(question);
+    const entropies = [];
+    for (const ans of answers) {
+      const sim = this.simulateAnswer(this.scores, question, ans);
+      entropies.push(this.computeEntropy(sim));
+    }
+    const expected = entropies.reduce((a,b)=>a+b,0) / answers.length;
+    const current = this.computeEntropy();
+    return current - expected;
+  }
+
+  selectBestQuestion() {
+    let best = null;
+    let bestIg = -Infinity;
+    for (const q of this.remaining) {
+      const ig = this.informationGainForQuestion(q);
+      if (ig > bestIg) {
+        bestIg = ig;
+        best = q;
+      }
+    }
+    return best;
+  }
+
+  getTopDiseases(n=3) {
+    const active = Object.entries(this.scores).filter(([,s]) => s !== -Infinity);
+    active.sort((a,b)=>b[1]-a[1]);
+    return active.slice(0,n);
+  }
+
+  getScores() {
+    const out = {};
+    for (const [d,s] of Object.entries(this.scores)) {
+      if (s !== -Infinity) out[d] = s;
+    }
+    return out;
+  }
+
+  isDone(maxQuestions=25) {
+    return this.history.length >= maxQuestions || this.remaining.size === 0;
+  }
+}
+
+export { DiagnosisEngine };

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AIVO Web</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 40px; }
+#question { font-size: 1.5em; margin-bottom: 20px; }
+.answer { margin: 5px; padding: 10px 20px; font-size: 1em; }
+#controls { margin-top: 20px; }
+</style>
+</head>
+<body>
+<h1>Veterinary Ophthalmology Diagnostic Tool</h1>
+<div id="question">Loading...</div>
+<div id="answers"></div>
+<pre id="progress"></pre>
+<div id="controls">
+<button id="back" style="display:none">Back</button>
+<button id="restart" style="display:none">Restart</button>
+</div>
+<script type="module" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple JS port of the diagnosis engine
- implement browser UI with back and restart support
- document how to launch the web version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b936f0bc8832f974a2380caab2d02